### PR TITLE
Fix no-arg push() call to return a key immediately.

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -124,7 +124,7 @@ function cancelCallback(removed: IListener[]): number {
   let count = 0;
   removed.forEach(l => {
     if (typeof l.cancelCallbackOrContext === "function") {
-      // l.cancelCallbackOrContext();
+      (l.cancelCallbackOrContext as any)();
       count++;
     }
   });

--- a/src/database.ts
+++ b/src/database.ts
@@ -8,6 +8,7 @@ import { key as fbKey } from "firebase-key";
 import { join, pathDiff, getParent, getKey, keyAndParent } from "./util";
 import * as convert from "typed-conversions";
 import SnapShot from "./snapshot";
+
 export let db: IDictionary = [];
 
 let _listeners: IListener[] = [];
@@ -21,6 +22,10 @@ export function updateDatabase(state: any) {
     ...db,
     ...state
   };
+}
+
+export function newId() {
+  return fbKey();
 }
 
 export function setDB(path: string, value: any) {
@@ -60,7 +65,7 @@ export function removeDB(path: string) {
 }
 
 export function pushDB(path: string, value: any): string {
-  const pushId = fbKey();
+  const pushId = newId();
   const fullPath = join(path, pushId);
 
   setDB(fullPath, value);

--- a/src/database.ts
+++ b/src/database.ts
@@ -65,6 +65,11 @@ export function updateDB(path: string, value: any) {
 }
 
 export function multiPathUpdateDB(data: IDictionary) {
+  // Currently this fires N notification events for each entry
+  // in data (e.g. if listening to /path and data has /path/1
+  // and /path/2, there are two events fired). Ideally we would
+  // apply all of the updates, and then fire a single notification
+  // event.
   Object.keys(data).map(key => setDB(key, data[key]));
 }
 

--- a/src/database.ts
+++ b/src/database.ts
@@ -102,6 +102,7 @@ export function addListener(
 }
 
 export function removeListener(
+  path: string,
   eventType?: rtdb.EventType,
   callback?: (snap: SnapShot, key?: string) => void,
   context?: IDictionary
@@ -110,30 +111,30 @@ export function removeListener(
     return removeAllListeners();
   }
 
+  path = join(path);
   if (!callback) {
-    const removed = _listeners.filter(l => l.eventType === eventType);
-    _listeners = _listeners.filter(l => l.eventType !== eventType);
+    const removed = _listeners.filter(l => l.path === path && l.eventType === eventType);
+    _listeners = _listeners.filter(l => l.path !== path || l.eventType !== eventType);
     return cancelCallback(removed);
   }
 
   if (!context) {
     const removed = _listeners
+      .filter(l => l.path === path)
       .filter(l => l.callback === callback)
       .filter(l => l.eventType === eventType);
-
-    _listeners = _listeners.filter(l => l.eventType !== eventType || l.callback !== callback);
-
+    _listeners = _listeners.filter(l =>
+      l.path !== path || l.eventType !== eventType || l.callback !== callback);
     return cancelCallback(removed);
   } else {
     const removed = _listeners
+      .filter(l => l.path === path)
       .filter(l => l.callback === callback)
       .filter(l => l.eventType === eventType)
       .filter(l => l.context === context);
-
-    _listeners = _listeners.filter(
-      l => l.context !== context || l.callback !== callback || l.eventType !== eventType
+    _listeners = _listeners.filter(l =>
+      l.path !== path || l.context !== context || l.callback !== callback || l.eventType !== eventType
     );
-
     return cancelCallback(removed);
   }
 }

--- a/src/database.ts
+++ b/src/database.ts
@@ -11,10 +11,15 @@ import SnapShot from "./snapshot";
 
 export let db: IDictionary = [];
 
+let _useDeterministicIds = false;
 let _listeners: IListener[] = [];
+let _nextId = 0;
 
 export function clearDatabase() {
   db = {};
+  // go back to fbKeys unless user re-opts in
+  _useDeterministicIds = false;
+  _nextId = 0;
 }
 
 export function updateDatabase(state: any) {
@@ -24,7 +29,15 @@ export function updateDatabase(state: any) {
   };
 }
 
-export function newId() {
+export function useDeterministicIds() {
+  _useDeterministicIds = true;
+}
+
+export function newId(): string {
+  if (_useDeterministicIds) {
+    // prefix id to keep firebase from thinking this is an array index
+    return 'id' + (++_nextId);
+  }
   return fbKey();
 }
 

--- a/src/database.ts
+++ b/src/database.ts
@@ -4,6 +4,7 @@ import { rtdb } from "firebase-api-surface";
 import { IListener } from "./query";
 import set = require("lodash.set");
 import get = require("lodash.get");
+import * as _ from "lodash";
 import { key as fbKey } from "firebase-key";
 import { join, pathDiff, getParent, getKey, keyAndParent } from "./util";
 import * as convert from "typed-conversions";
@@ -187,7 +188,7 @@ function notify(dotPath: string, newValue: any, oldValue: any) {
         result = get(db, l.path);
         delete result[getKey(dotPath)];
       } else {
-        set(result, pathDiff(dotPath, l.path), newValue);
+        result = _.cloneDeep(listeningRoot);
       }
       return l.callback(new SnapShot(join(l.path), result));
     });

--- a/src/database.ts
+++ b/src/database.ts
@@ -41,12 +41,16 @@ export function newId(): string {
   return fbKey();
 }
 
-export function setDB(path: string, value: any) {
+export function setDB(path: string, value: any): void {
   const dotPath = join(path);
   const oldValue = get(db, dotPath);
 
   set(db, dotPath, value);
   notify(dotPath, value, oldValue);
+}
+
+export function getDB(path: string): any {
+  return get(db, join(path), undefined);
 }
 
 /** single-path update */

--- a/src/mock.ts
+++ b/src/mock.ts
@@ -8,7 +8,7 @@ import Deployment from "./deployment";
 import SchemaHelper from "./schema-helper";
 import Schema from "./schema";
 import Queue from "./queue";
-import { db, clearDatabase, updateDatabase } from "./database";
+import { db, clearDatabase, updateDatabase, useDeterministicIds } from "./database";
 import {
   getRandomInt,
   normalizeRef,
@@ -123,5 +123,10 @@ export default class Mock {
 
   public ref<T = any>(dbPath: string) {
     return new Reference<T>(dbPath);
+  }
+
+  public useDeterministicIds(): Mock {
+    useDeterministicIds();
+    return this;
   }
 }

--- a/src/mock.ts
+++ b/src/mock.ts
@@ -2,7 +2,6 @@ import { IDictionary } from "common-types";
 import set = require("lodash.set");
 import get = require("lodash.get");
 import first = require("lodash.first");
-import * as fbKey from "firebase-key";
 import SnapShot from "./snapshot";
 import Reference from "./reference";
 import Deployment from "./deployment";

--- a/src/mock.ts
+++ b/src/mock.ts
@@ -8,7 +8,7 @@ import Deployment from "./deployment";
 import SchemaHelper from "./schema-helper";
 import Schema from "./schema";
 import Queue from "./queue";
-import { db, clearDatabase, updateDatabase, useDeterministicIds } from "./database";
+import { db, clearDatabase, updateDatabase, useDeterministicIds, getDB } from "./database";
 import {
   getRandomInt,
   normalizeRef,
@@ -123,6 +123,10 @@ export default class Mock {
 
   public ref<T = any>(dbPath: string) {
     return new Reference<T>(dbPath);
+  }
+
+  public get(dbPath: string) {
+    return getDB(dbPath);
   }
 
   public useDeterministicIds(): Mock {

--- a/src/query.ts
+++ b/src/query.ts
@@ -144,8 +144,13 @@ export default class Query<T = any> implements rtdb.IQuery {
     context?: object | null
   ): (a: rtdb.IDataSnapshot | null, b?: string) => any {
     addListener(this.path, eventType, callback, cancelCallbackOrContext, context);
-
-    return null;
+    if (eventType === "value") {
+      const current = this.onceSync("value");
+      if (current && current.val()) {
+        networkDelay(null).then(() => callback(current));
+      }
+    }
+    return callback;
   }
 
   public once(eventType: "value"): Promise<rtdb.IDataSnapshot<T>> {

--- a/src/query.ts
+++ b/src/query.ts
@@ -148,8 +148,8 @@ export default class Query<T = any> implements rtdb.IQuery {
     return null;
   }
 
-  public once(eventType: "value") {
-    return networkDelay(this.process()) as Promise<rtdb.IDataSnapshot<T>>;
+  public once(eventType: "value"): Promise<rtdb.IDataSnapshot<T>> {
+    return networkDelay(this.process());
   }
 
   public onceSync(eventType: "value"): rtdb.IDataSnapshot<T> {

--- a/src/query.ts
+++ b/src/query.ts
@@ -1,7 +1,7 @@
 import { IDictionary } from "common-types";
 // tslint:disable-next-line:no-implicit-dependencies
 import { rtdb } from "firebase-api-surface";
-import { db, addListener } from "./database";
+import { db, addListener, removeListener } from "./database";
 import get = require("lodash.get");
 import SnapShot from "./snapshot";
 import Queue from "./queue";
@@ -134,7 +134,6 @@ export default class Query<T = any> implements rtdb.IQuery {
       });
     };
     this._queryFilters.push(filter);
-
     return this;
   }
 
@@ -157,8 +156,11 @@ export default class Query<T = any> implements rtdb.IQuery {
     return this.process();
   }
 
-  public off() {
-    console.log("off() not implemented yet");
+  public off(
+    eventType: rtdb.EventType,
+    callback: (a: rtdb.IDataSnapshot<T> | null, b?: string) => any,
+    context?: object | null): void {
+    removeListener(this.path, eventType, callback, context);
   }
 
   /** NOT IMPLEMENTED YET */

--- a/src/query.ts
+++ b/src/query.ts
@@ -162,8 +162,8 @@ export default class Query<T = any> implements rtdb.IQuery {
   }
 
   public off(
-    eventType: rtdb.EventType,
-    callback: (a: rtdb.IDataSnapshot<T> | null, b?: string) => any,
+    eventType?: rtdb.EventType,
+    callback?: (a: rtdb.IDataSnapshot<T> | null, b?: string) => any,
     context?: object | null): void {
     removeListener(this.path, eventType, callback, context);
   }

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -95,6 +95,10 @@ export default class Reference<T = any> extends Query<T> implements IReference {
     return networkDelay<void>();
   }
 
+  public setSync(value: any): void {
+    setDB(this.path, value);
+  }
+
   public update(values: IDictionary, onComplete?: (a: Error | null) => any): Promise<void> {
     if (isMultiPath(values)) {
       multiPathUpdateDB(values);

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -1,13 +1,12 @@
 // tslint:disable:no-implicit-dependencies
 import { rtdb } from "firebase-api-surface";
-import { key as fbKey } from "firebase-key";
 import { IDictionary } from "common-types";
 import Query from "./query";
 import SnapShot from "./snapshot";
 import Disconnected from "./disconnected";
 import get = require("lodash.get");
 
-import { db, setDB, updateDB, pushDB, removeDB, multiPathUpdateDB } from "./database";
+import { db, setDB, updateDB, newId, pushDB, removeDB, multiPathUpdateDB } from "./database";
 import {
   parts,
   normalizeRef,
@@ -69,7 +68,7 @@ export default class Reference<T = any> extends Query<T> implements IReference {
       }
       return then;
     } else {
-      const id = fbKey();
+      const id = newId();
       const ref = new Reference<T>(join(this.path, id), db);
       // no-arg push should not have any network delay
       const then = new ThenableReference<T>(join(this.path, id), db, Promise.resolve(ref));
@@ -152,7 +151,7 @@ export class ThenableReference<T = any> extends Reference<T> implements IThenabl
     super(path, delay);
   }
 
-  then<TResult1 = IReference<T>, TResult2 = never>(
+  public then<TResult1 = IReference<T>, TResult2 = never>(
     onfulfilled?: ((value: IReference<T>) => TResult1 | PromiseLike<TResult1>) | undefined | null,
     onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): PromiseLike<TResult1 | TResult2> {
     return this.promise.then(onfulfilled, onrejected);

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -81,18 +81,20 @@ export default class Reference<T = any> extends Query<T> implements IReference {
 
   public remove(onComplete?: (a: Error | null) => any): Promise<void> {
     removeDB(this.path);
-    if (onComplete) {
-      onComplete(null);
-    }
-    return networkDelay<void>();
+    return networkDelay<void>().then(() => {
+      if (onComplete) {
+        onComplete(null);
+      }
+    });
   }
 
   public set(value: any, onComplete?: (a: Error | null) => any): Promise<void> {
     setDB(this.path, value);
-    if (onComplete) {
-      onComplete(null);
-    }
-    return networkDelay<void>();
+    return networkDelay<void>().then(() => {
+      if (onComplete) {
+        onComplete(null);
+      }
+    });
   }
 
   public setSync(value: any): void {
@@ -105,10 +107,11 @@ export default class Reference<T = any> extends Query<T> implements IReference {
     } else {
       updateDB(this.path, values);
     }
-    if (onComplete) {
-      onComplete(null);
-    }
-    return networkDelay<void>();
+    return networkDelay<void>().then(() => {
+      if (onComplete) {
+        onComplete(null);
+      }
+    });
   }
 
   public setPriority(

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,5 +1,4 @@
 import { IDictionary } from "common-types";
-import * as fbKey from "firebase-key";
 import set = require("lodash.set");
 import get = require("lodash.get");
 import first = require("lodash.first");
@@ -39,7 +38,7 @@ export default class Schema<T = any> {
   private _relationships = new Queue<IRelationship>("relationships");
   private _prefix: string = "";
 
-  constructor(public schemaId: string) {}
+  constructor(public schemaId: string) { }
 
   /**
    * Add a mocking function to be used to generate the schema in mock DB

--- a/src/util.ts
+++ b/src/util.ts
@@ -139,11 +139,11 @@ export function setNetworkDelay(
   _delay = value;
 }
 
-export function networkDelay<T = any>(returnValue?: any): Promise<T> {
+export function networkDelay<T = any>(returnValue?: T): Promise<T> {
   return new Promise(resolve => {
     setTimeout(() => {
       if (returnValue) {
-        resolve(returnValue as T);
+        resolve(returnValue);
       } else {
         resolve();
       }

--- a/test/database-spec.ts
+++ b/test/database-spec.ts
@@ -62,7 +62,7 @@ describe("Database", () => {
       addListener("/path/to/node", "value", callback);
       addListener("/path/to/node", "value", callback);
       expect(listenerCount()).to.equal(3);
-      removeListener();
+      removeListener("/path/to/node");
       expect(listenerCount()).to.equal(0);
       addListener("/path/to/node", "value", callback);
       addListener("/path/to/node", "value", callback);
@@ -71,17 +71,18 @@ describe("Database", () => {
       removeAllListeners();
     });
 
-    it("can remove all listeners of given eventType", () => {
+    it("can remove listeners of given eventType", () => {
       const callback: GenericEventHandler = snap => undefined;
       removeAllListeners();
       addListener("/path/to/value1", "value", callback);
       addListener("/path/to/added", "child_added", callback);
       addListener("/path/to/value2", "value", callback);
       addListener("/path/to/moved", "child_moved", callback);
-      removeListener("child_added");
+      removeListener("/path/to/added", "child_added");
       expect(listenerCount()).to.equal(3);
       listenerPaths().forEach(p => expect(p).to.not.include("added"));
-      removeListener("value");
+      removeListener("/path/to/value1", "value");
+      removeListener("/path/to/value2", "value");
       expect(listenerCount()).to.equal(1);
       listenerPaths().forEach(p => expect(p).to.include("moved"));
     });
@@ -95,7 +96,8 @@ describe("Database", () => {
       addListener("/path/to/added", "child_added", callback);
       addListener("/path/to/value3", "value", callback2);
       addListener("/path/to/moved", "child_moved", callback);
-      removeListener("value", callback);
+      removeListener("/path/to/value1", "value", callback);
+      removeListener("/path/to/value2", "value", callback);
       expect(listenerCount()).to.equal(3);
       expect(listenerCount("value")).to.equal(1);
       listenerPaths("value").forEach(l => expect(l).to.include("value3"));
@@ -113,7 +115,7 @@ describe("Database", () => {
       addListener("/path/to/value3", "value", callback2, null, context2);
       addListener("/path/to/moved", "child_moved", callback, null, context);
       expect(listenerCount()).to.equal(5);
-      removeListener("value", callback2, context2);
+      removeListener("/path/to/value2", "value", callback2, context);
       expect(listenerCount()).to.equal(4);
       expect(listenerPaths("value")).to.be.length(2);
     });
@@ -137,8 +139,10 @@ describe("Database", () => {
       addListener("/path/to/added", "child_added", callback, cancelCallback);
       addListener("/path/to/value3", "value", callback2);
       addListener("/path/to/moved", "child_moved", callback);
-      howMany = removeListener("value");
-      expect(howMany).to.equal(2);
+      howMany = removeListener("/path/to/value1", "value");
+      expect(howMany).to.equal(1);
+      howMany = removeListener("/path/to/value2", "value");
+      expect(howMany).to.equal(1);
       expect(count).to.equal(5);
     });
   });

--- a/test/reference-spec.ts
+++ b/test/reference-spec.ts
@@ -495,6 +495,12 @@ describe("Reference functions", () => {
       expect(helpers.firstRecord(people).name).to.equal("Happy Jack");
     });
 
+    it("push() with no value returns new key immediately", () => {
+      const m = new Mock();
+      let key = m.ref("/people").push().key;
+      expect(key).to.be.not.undefined;
+    });
+
     it("push() can push scalar", async () => {
       const m = new Mock();
       await m.ref("/data").push(444);


### PR DESCRIPTION
Thanks for firemock; it's a great idea, much better than testing with real wire calls.

I just started using it, and noticed `push().key` didn't work as expected, so made a fix for that. 