### PR TITLE
[BUGFIX] Datasnapshot exists check by undefined

### DIFF
--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -65,7 +65,7 @@ export default class SnapShot<T = any> implements rtdb.IDataSnapshot {
   }
 
   public exists(): boolean {
-    return this._value !== null;
+    return this._value !== null && this._value !== undefined;
   }
 
   public forEach(actionCb: Action) {


### PR DESCRIPTION
Hi,
I found that datasnapshot can be undefined and in your code only checks for nulls, so i added this check.


Here is an example of this bug
```
describe('Bug', ()=>{
  let databaseMock;
  before(() => {
    const Mock = require('firemock').Mock;
    databaseMock = new Mock(
      {
        place:{
          'id1':{
            id: "-hello"
          },
          'id2':{
            id: "-bye"
          },
        }
      });
  });

  after(() => {
  });

  it('should be fail', ()=>{
    const path = 'place/id3';
    return databaseMock.ref(path).set({id:'bug'}).then(()=>{
      return databaseMock.ref(path).remove().then(()=>{
        const elementDeleted = databaseMock.ref(path).onceSync("value");
        assert.isUndefined(elementDeleted.val()); // this works
        assert.isFalse(elementDeleted.exists()); // this fail
      })
    });
  })
});
```

thanks!